### PR TITLE
Replace database.txt with $database

### DIFF
--- a/contactManager.sh
+++ b/contactManager.sh
@@ -4,6 +4,9 @@
 # Carlo Rodriguez
 # Benjamin Winston
 
+#Parameters
+database=database.txt
+
 # Defining Find() function
 Find() {
     if [ "$#" -eq 0 ]; then
@@ -14,7 +17,7 @@ Find() {
 
     echo
     
-    if ! grep -q "$reply" database.txt; then
+    if ! grep -q "$reply" $database; then
 	echo "Record not found."
 	echo
 	return 1
@@ -32,7 +35,7 @@ Find() {
 	return 1
     fi 
 
-    iconv -l | grep "$reply" database.txt | head -5 | tr ':' ' '
+    iconv -l | grep "$reply" $database | head -5 | tr ':' ' '
 
     echo
 }


### PR DESCRIPTION
The add() function has the $database variable, but it's something necessary to all functions.  Moving it to a global parameter area.  Also replaced database.txt in find() function.